### PR TITLE
feat: add multicontract support with min fee limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ We made this thing for the purpose of minting and transferring NFTs, transferrin
 It polls a database for work to do at a configured minimum interval (but will always wait for a batch to be confirmed before pulling another one). Currently it runs with an unencrypted private key in an in-memory signer, it's not nice but it's fast, and the signer is relatively simple to replace if needed (but it has to be able to sign without user input - so hardware wallets won't work, sorry).
 
 ## Prerequisites
+
 - node.js version 16+
 - npm 7+
 - postgresql (tested with version 12)
 
 ## Installation
 
-In this directory 
+In this directory
 
 `npm install`
 
@@ -27,7 +28,7 @@ To enable remote signer support, remove `privateKey` from `config.json` and conf
 
 This version of Peppermint allows multiple instances of handlers to be configured via `config.json`. In the `handlers` section, one can add multiple instances of the same handler module with different arguments, under different names. The names specified here will be used as the handler names in the SQL commands.
 
-At this moment, to reduce complexity, handler modules are *not* auto-populated from the `operations` folder, but imported manually in `app.mjs` - so when adding new, custom handler modules, these need to be specifically imported and added to the `Handlers` object in that file.
+At this moment, to reduce complexity, handler modules are _not_ auto-populated from the `operations` folder, but imported manually in `app.mjs` - so when adding new, custom handler modules, these need to be specifically imported and added to the `Handlers` object in that file.
 
 ## How to run
 
@@ -38,6 +39,7 @@ At this moment, to reduce complexity, handler modules are *not* auto-populated f
 The database table used for queuing work is defined as a Postgres schema in `database/schema.sql`.
 
 To add a new work item, fill in the follwing fields:
+
 - `originator`: The address the operation should be originated from. A process will only pull work with an `originator` value that matches the address of its signer
 - `command`: A json structure, with the following fields:
   - `handler`: The name of the handler instance to invoke (configured via the `handlers` section in `config.json`)
@@ -49,14 +51,31 @@ To add a new work item, fill in the follwing fields:
 In the current state of the codebase, failed operations won't be retried except for a few known retriable fail states (known Octez glitches, no tez in minter account).
 
 Modules for handling contract types can be added under `operations`. The handler modules included in this version are:
+
 - FA2 multi-asset (as 'nft' - we know it's a misnomer, but it's what it is for now)
 - tez (for plain tez transfers)
 
 For now, the code is the documentation. We're truly sorry. More documentation will come in due time. In the meantime, here are some example operations you can do:
 
+### Command JSON for minting NFTs with multicontract handler
+
+```json
+{
+	"handler": "nft-multicontract",
+	"name": "create_and_mint",
+	"args": {
+		"token_id": 1, // integer token id
+		"to_address" : "tz1xxx", // Tezos address to which the NFT will be assigned
+		"contract_address" : "KT1xxx", // Contract address to which the NFT will be created and minted
+		"metadata_ipfs": "ipfs://xxx" // ipfs URI pointing to TZIP-16 metadata
+		"amount" : 1 // (optional) integer amount of edition size to be minted
+	}
+}
+```
+
 ### Command JSON for minting NFTs
 
-```
+```json
 {
 	"handler": "nft",
 	"name": "create_and_mint",
@@ -71,22 +90,22 @@ For now, the code is the documentation. We're truly sorry. More documentation wi
 
 ### Command JSON for transferring NFTs
 
-```
+```json
 {
-	"handler": "nft",
-	"name": "transfer",
-	"args": {
-		"token_id": 1, // integer token id
-		"from_address" : "tz2xxx", // Tezos address from which the NFT will be transferred
-		"to_address" : "tz1xxx", // Tezos address to which the NFT will be transferred
-		"amount" : 1 // (optional) integer amount of tokens to transfer
-	}
+  "handler": "nft",
+  "name": "transfer",
+  "args": {
+    "token_id": 1, // integer token id
+    "from_address": "tz2xxx", // Tezos address from which the NFT will be transferred
+    "to_address": "tz1xxx", // Tezos address to which the NFT will be transferred
+    "amount": 1 // (optional) integer amount of tokens to transfer
+  }
 }
 ```
 
 ### Command JSON for transferring tez
 
-```
+```json
 {
 	"handler": "tez",
 	"name": "transfer",

--- a/app.mjs
+++ b/app.mjs
@@ -209,7 +209,7 @@ const main = async function() {
 						// The call failed on some business logic check in the contract
 					default:
 						// Everything else
-						logger.error(`Non-retriable Tezos error encountered:\n${tezos_error}\nRejecting operations with ids:${JSON.stringify(batched_ids)}`);
+						logger.error(`Non-retriable Tezos error encountered:\n${JSON.stringify(tezos_error)}\nRejecting operations with ids:${JSON.stringify(batched_ids)}`);
 						save_state_async(batched_ids, queue.state.REJECTED);
 				}
 				return true;

--- a/config.example.json
+++ b/config.example.json
@@ -24,7 +24,8 @@
 		"nft-multicontract": {
 			"handler": "MulticontractHandler",
 			"args": {
-				"storageLimit": 100
+				"storageLimit": 1000,
+				"gasLimit": 3000
 			}
 		},
 		"nft": {

--- a/config.example.json
+++ b/config.example.json
@@ -21,6 +21,12 @@
  		"database": "tezos"
 	},
 	"handlers": {
+		"nft-multicontract": {
+			"handler": "MulticontractHandler",
+			"args": {
+				"storageLimit": 100
+			}
+		},
 		"nft": {
 			"handler": "MultiassetHandler",
 			"args": {

--- a/operations/nft-multicontract.mjs
+++ b/operations/nft-multicontract.mjs
@@ -23,11 +23,17 @@ export default async function (tezos, { gasLimit, storageLimit }) {
   };
 
   const op_to_transfer = async function (op) {
-    const estimate = await tezos.estimate.transfer(op.toTransferParams());
+    let estimate = null;
+    try {
+      estimate = await tezos.estimate.transfer(op.toTransferParams());
+    } catch (err) {
+      logger.error(`failed to estimate operation: ${err}`);
+    }
     const params = op.toTransferParams({
-      gasLimit: Math.max(estimate.gasLimit ?? 0, gasLimit ?? 0),
-      storageLimit: Math.max(estimate.storageLimit ?? 0, storageLimit ?? 0),
+      gasLimit: Math.max(estimate?.gasLimit ?? 0, gasLimit ?? 0),
+      storageLimit: Math.max(estimate?.storageLimit ?? 0, storageLimit ?? 0),
     });
+    logger.info(`transfer params: ${JSON.stringify(params)}`);
     return params;
   };
 

--- a/operations/nft-multicontract.mjs
+++ b/operations/nft-multicontract.mjs
@@ -23,6 +23,7 @@ export default async function (tezos, { gasLimit, storageLimit }) {
   };
 
   const op_to_transfer = async function (op) {
+    /*
     let estimate = null;
     try {
       estimate = await tezos.estimate.transfer(op.toTransferParams());
@@ -33,6 +34,8 @@ export default async function (tezos, { gasLimit, storageLimit }) {
       gasLimit: Math.max(estimate?.gasLimit ?? 0, gasLimit ?? 0),
       storageLimit: Math.max(estimate?.storageLimit ?? 0, storageLimit ?? 0),
     });
+    */
+    const params = op.toTransferParams();
     logger.info(`transfer params: ${JSON.stringify(params)}`);
     return params;
   };

--- a/operations/nft-multicontract.mjs
+++ b/operations/nft-multicontract.mjs
@@ -1,72 +1,112 @@
-//import { TezosToolkit } from "@taquito/taquito";
-import { MichelsonMap, TezosPreapplyFailureError } from '@taquito/taquito'
-import { char2Bytes } from '@taquito/utils'
-import { logger } from '../logger.mjs';
-// import { createRequire } from 'module'
-// const require = createRequire(import.meta.url);
+import { MichelsonMap } from "@taquito/taquito";
+import { char2Bytes } from "@taquito/utils";
+import { logger } from "../logger.mjs";
 
-// const hex = require('string-hex');
-// const utf8 = require('utf8')
+export default async function (tezos, { gasLimit, storageLimit }) {
+  const loaded_contracts = {};
+  const load_contract = async function (contract_address) {
+    if (contract_address in loaded_contracts === false) {
+      loaded_contracts[contract_address] = await tezos.contract.at(
+        contract_address
+      );
+      logger.info(
+        `token contract ${contract_address} loaded ${loaded_contracts[
+          contract_address
+        ].parameterSchema.ExtractSignatures()}`
+      );
+    }
+    return {
+      create_token: loaded_contracts[contract_address].methods.create_token,
+      mint_tokens: loaded_contracts[contract_address].methods.mint_tokens,
+      transfer_tokens: loaded_contracts[contract_address].methods.transfer,
+    };
+  };
 
-export default async function(tezos, { gasLimit, storageLimit }) {
-	let loaded_contracts = {};
-	let load_contract = async function(contract_address) {
-		if (contract_address in loaded_contracts === false) {
-			loaded_contracts[contract_address] = await tezos.contract.at(contract_address);
-			logger.info(`token contract ${contract_address} loaded ${loaded_contracts[contract_address].parameterSchema.ExtractSignatures()}`);
-		}
-		return {
-			create_token: loaded_contracts[contract_address].methods.create_token,
-			mint_tokens: loaded_contracts[contract_address].methods.mint_tokens,
-			transfer_tokens: loaded_contracts[contract_address].methods.transfer
-		}
-	}
+  const op_to_transfer = async function (op) {
+    const estimate = await tezos.estimate.transfer(op.toTransferParams());
+    const params = op.toTransferParams({
+      gasLimit: Math.max(estimate.gasLimit ?? 0, gasLimit ?? 0),
+      storageLimit: Math.max(estimate.storageLimit ?? 0, storageLimit ?? 0),
+    });
+    return params;
+  };
 
-	let op_to_transfer = async function(op) {
-		let estimate = await tezos.estimate.transfer(op.toTransferParams());
-		let params = op.toTransferParams({
-			gasLimit: Math.max(estimate.gasLimit ?? 0, gasLimit ?? 0),
-			storageLimit: Math.max(estimate.storageLimit ?? 0, storageLimit ?? 0),
-		});
-		return params
-	}
+  const create_token = async function (
+    contract_address,
+    token_id,
+    metadata_ipfs
+  ) {
+    const contract_ops = await load_contract(contract_address);
+    if (typeof contract_ops.create_token != "function") {
+      throw new Error("No create_token entrypoint on contract");
+    }
+    const token_info = MichelsonMap.fromLiteral({
+      "": char2Bytes(metadata_ipfs),
+    });
+    const create_op = contract_ops.create_token(token_id, token_info);
+    return create_op;
+  };
 
-	let create_token = async function(contract_address, token_id, metadata_ipfs) {
-		let contract_ops = await load_contract(contract_address);
-		if (typeof contract_ops.create_token != 'function') {
-			throw new Error("No create_token entrypoint on contract");
-		}
-		let token_info = MichelsonMap.fromLiteral({"": char2Bytes(metadata_ipfs)});
-		let create_op = contract_ops.create_token(token_id, token_info);
-		return create_op;
-	};
+  const mint_token = async function (
+    contract_address,
+    token_id,
+    to_address,
+    amount = 1
+  ) {
+    const contract_ops = await load_contract(contract_address);
+    if (typeof contract_ops.mint_tokens != "function") {
+      throw new Error("No mint_tokens entrypoint on contract");
+    }
+    const mint_op = contract_ops.mint_tokens([
+      { owner: to_address, token_id, amount },
+    ]);
+    return mint_op;
+  };
 
-	let mint_token = async function(contract_address, token_id, to_address, amount = 1) {
-		let contract_ops = await load_contract(contract_address);
-		if (typeof contract_ops.mint_tokens != 'function') {
-			throw new Error("No mint_tokens entrypoint on contract");
-		}
-		let mint_op = contract_ops.mint_tokens([{ owner: to_address, token_id, amount }]);
-		return mint_op;
-	};
-
-	return {
-		create: async function({ contract_address, token_id, metadata_ipfs }, batch) {
-			let create_op = await create_token(contract_address, token_id, metadata_ipfs);
-			batch.withTransfer(await op_to_transfer(create_op));
-			return true;
-		},
-		mint: async function({ contract_address, token_id, to_address, amount }, batch) {
-			let mint_op = await mint_token(contract_address, token_id, to_address, amount);
-			batch.withTransfer(await op_to_transfer(mint_op));
-			return true;
-		},
-		create_and_mint: async function({ contract_address, token_id, to_address, metadata_ipfs, amount }, batch) {
-			let create_op = await create_token(contract_address, token_id, metadata_ipfs);
-			let mint_op = await mint_token(contract_address, token_id, to_address, amount);
-			batch.withTransfer(await op_to_transfer(create_op));
-			batch.withTransfer(await op_to_transfer(mint_op));
-			return true;
-		},
-	};
+  return {
+    create: async function (
+      { contract_address, token_id, metadata_ipfs },
+      batch
+    ) {
+      const create_op = await create_token(
+        contract_address,
+        token_id,
+        metadata_ipfs
+      );
+      batch.withTransfer(await op_to_transfer(create_op));
+      return true;
+    },
+    mint: async function (
+      { contract_address, token_id, to_address, amount },
+      batch
+    ) {
+      const mint_op = await mint_token(
+        contract_address,
+        token_id,
+        to_address,
+        amount
+      );
+      batch.withTransfer(await op_to_transfer(mint_op));
+      return true;
+    },
+    create_and_mint: async function (
+      { contract_address, token_id, to_address, metadata_ipfs, amount },
+      batch
+    ) {
+      const create_op = await create_token(
+        contract_address,
+        token_id,
+        metadata_ipfs
+      );
+      const mint_op = await mint_token(
+        contract_address,
+        token_id,
+        to_address,
+        amount
+      );
+      batch.withTransfer(await op_to_transfer(create_op));
+      batch.withTransfer(await op_to_transfer(mint_op));
+      return true;
+    },
+  };
 }

--- a/operations/nft-multicontract.mjs
+++ b/operations/nft-multicontract.mjs
@@ -1,0 +1,72 @@
+//import { TezosToolkit } from "@taquito/taquito";
+import { MichelsonMap, TezosPreapplyFailureError } from '@taquito/taquito'
+import { char2Bytes } from '@taquito/utils'
+import { logger } from '../logger.mjs';
+// import { createRequire } from 'module'
+// const require = createRequire(import.meta.url);
+
+// const hex = require('string-hex');
+// const utf8 = require('utf8')
+
+export default async function(tezos, { gasLimit, storageLimit }) {
+	let loaded_contracts = {};
+	let load_contract = async function(contract_address) {
+		if (contract_address in loaded_contracts === false) {
+			loaded_contracts[contract_address] = await tezos.contract.at(contract_address);
+			logger.info(`token contract ${contract_address} loaded ${loaded_contracts[contract_address].parameterSchema.ExtractSignatures()}`);
+		}
+		return {
+			create_token: loaded_contracts[contract_address].methods.create_token,
+			mint_tokens: loaded_contracts[contract_address].methods.mint_tokens,
+			transfer_tokens: loaded_contracts[contract_address].methods.transfer
+		}
+	}
+
+	let op_to_transfer = async function(op) {
+		let estimate = await tezos.estimate.transfer(op.toTransferParams());
+		let params = op.toTransferParams({
+			gasLimit: Math.max(estimate.gasLimit ?? 0, gasLimit ?? 0),
+			storageLimit: Math.max(estimate.storageLimit ?? 0, storageLimit ?? 0),
+		});
+		return params
+	}
+
+	let create_token = async function(contract_address, token_id, metadata_ipfs) {
+		let contract_ops = await load_contract(contract_address);
+		if (typeof contract_ops.create_token != 'function') {
+			throw new Error("No create_token entrypoint on contract");
+		}
+		let token_info = MichelsonMap.fromLiteral({"": char2Bytes(metadata_ipfs)});
+		let create_op = contract_ops.create_token(token_id, token_info);
+		return create_op;
+	};
+
+	let mint_token = async function(contract_address, token_id, to_address, amount = 1) {
+		let contract_ops = await load_contract(contract_address);
+		if (typeof contract_ops.mint_tokens != 'function') {
+			throw new Error("No mint_tokens entrypoint on contract");
+		}
+		let mint_op = contract_ops.mint_tokens([{ owner: to_address, token_id, amount }]);
+		return mint_op;
+	};
+
+	return {
+		create: async function({ contract_address, token_id, metadata_ipfs }, batch) {
+			let create_op = await create_token(contract_address, token_id, metadata_ipfs);
+			batch.withTransfer(await op_to_transfer(create_op));
+			return true;
+		},
+		mint: async function({ contract_address, token_id, to_address, amount }, batch) {
+			let mint_op = await mint_token(contract_address, token_id, to_address, amount);
+			batch.withTransfer(await op_to_transfer(mint_op));
+			return true;
+		},
+		create_and_mint: async function({ contract_address, token_id, to_address, metadata_ipfs, amount }, batch) {
+			let create_op = await create_token(contract_address, token_id, metadata_ipfs);
+			let mint_op = await mint_token(contract_address, token_id, to_address, amount);
+			batch.withTransfer(await op_to_transfer(create_op));
+			batch.withTransfer(await op_to_transfer(mint_op));
+			return true;
+		},
+	};
+}


### PR DESCRIPTION
### Overview
This PR adds multi-contract and manually fee configuration for the multi-contract handler.

### Description
The `MulticontractHandler` can be configured with `gasLimit` and `storageLimit` args that will be the lower limit for each operation to avoid operation failures. Each command in the `MulticontractHandler` is the same format with the additional `contract_address` for specifying the target contract. The originator still needs to be the contract admin.
